### PR TITLE
Kubeadm audit webhook

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -308,7 +308,7 @@ type AuditPolicyConfiguration struct {
 	// WebhookConfigPath is the local path to webhook policy.
 	WebhookConfigPath string
 	// WebhookInitialBackoff is the time to wait (in seconds) before retrying the first failed request.
-	WebhookInitialBackoff *int32 //defaults to 10s if not provided
+	WebhookInitialBackoff string //defaults to 10s if not provided
 	//TODO(chuckha) add other options for audit policy.
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -286,6 +286,6 @@ type AuditPolicyConfiguration struct {
 	// WebhookConfigPath is the local path to webhook policy.
 	WebhookConfigPath string `json:"webhookConfigPath"`
 	// WebhookInitialBackoff is the time to wait (in seconds) before retrying the first failed request.
-	WebhookInitialBackoff *int32 `json:"webhookInitialBackoff,omitempty"`
+	WebhookInitialBackoff string `json:"webhookInitialBackoff,omitempty"`
 	//TODO(chuckha) add other options for audit policy.
 }

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -249,6 +249,8 @@ const (
 	AuditPolicyDir = "audit"
 	// AuditPolicyFile is the name of the audit policy file itself
 	AuditPolicyFile = "audit.yaml"
+	// KubeAuditWebhookConfigVolumeName is the name of the volume that will contain the audit webhook config
+	KubeAuditWebhookConfigVolumeName = "audit-webhook-config"
 	// AuditWebhookConfigFile is the name of the audit webhook config file itself
 	AuditWebhookConfigFile = "webhook.yaml"
 	// AuditPolicyLogFile is the name of the file audit logs get written to

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -258,8 +258,8 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration, k8sVersion *versio
 		if cfg.AuditPolicyConfiguration.WebhookConfigPath != "" {
 			command = append(command, "--audit-webhook-config-file="+kubeadmconstants.GetStaticPodAuditWebhookConfigFile())
 		}
-			command = append(command, fmt.Sprintf("--audit-webhook-initial-backoff=%d", *cfg.AuditPolicyConfiguration.WebhookInitialBackoff))
 		if cfg.AuditPolicyConfiguration.WebhookInitialBackoff != "" {
+			command = append(command, fmt.Sprintf("--audit-webhook-initial-backoff=%s", cfg.AuditPolicyConfiguration.WebhookInitialBackoff))
 		}
 	}
 

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -255,7 +255,7 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration, k8sVersion *versio
 		} else {
 			command = append(command, fmt.Sprintf("--audit-log-maxage=%d", *cfg.AuditPolicyConfiguration.LogMaxAge))
 		}
-		if cfg.AuditPolicyConfiguration.WebhookConfigPath != nil {
+		if cfg.AuditPolicyConfiguration.WebhookConfigPath != "" {
 			command = append(command, "--audit-webhook-config-file="+kubeadmconstants.GetStaticPodAuditWebhookConfigFile())
 		}
 			command = append(command, fmt.Sprintf("--audit-webhook-initial-backoff=%d", *cfg.AuditPolicyConfiguration.WebhookInitialBackoff))

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -258,8 +258,8 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration, k8sVersion *versio
 		if cfg.AuditPolicyConfiguration.WebhookConfigPath != nil {
 			command = append(command, "--audit-webhook-config-file="+kubeadmconstants.GetStaticPodAuditWebhookConfigFile())
 		}
-		if cfg.AuditPolicyConfiguration.WebhookInitialBackoff != nil {
 			command = append(command, fmt.Sprintf("--audit-webhook-initial-backoff=%d", *cfg.AuditPolicyConfiguration.WebhookInitialBackoff))
+		if cfg.AuditPolicyConfiguration.WebhookInitialBackoff != "" {
 		}
 	}
 

--- a/cmd/kubeadm/app/phases/controlplane/volumes.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes.go
@@ -62,7 +62,7 @@ func getHostPathVolumesForTheControlPlane(cfg *kubeadmapi.MasterConfiguration) c
 		mounts.NewHostPathMount(kubeadmconstants.KubeAPIServer, kubeadmconstants.KubeAuditPolicyVolumeName, cfg.AuditPolicyConfiguration.Path, kubeadmconstants.GetStaticPodAuditPolicyFile(), true, &hostPathFile)
 		// Read-only mount for the audit webhook config file.
 		// TODO(hh) If we aren't provided a webhook config, it might be useful to forgo this mount
-		mounts.NewHostPathMount(kubeadmconstants.KubeAPIServer, kubeadmconstants.KubeAuditPolicyVolumeName, cfg.AuditPolicyConfiguration.Path, kubeadmconstants.GetStaticPodAuditWebhookConfigFile(), true, &hostPathFile)
+		mounts.NewHostPathMount(kubeadmconstants.KubeAPIServer, kubeadmconstants.KubeAuditWebhookConfigVolumeName, cfg.AuditPolicyConfiguration.WebhookConfigPath, kubeadmconstants.GetStaticPodAuditWebhookConfigFile(), true, &hostPathFile)
 		// Write mount for the audit logs.
 		mounts.NewHostPathMount(kubeadmconstants.KubeAPIServer, kubeadmconstants.KubeAuditPolicyLogVolumeName, cfg.AuditPolicyConfiguration.LogDir, kubeadmconstants.StaticPodAuditPolicyLogDir, false, &hostPathDirectoryOrCreate)
 	}

--- a/cmd/kubeadm/app/util/audit/utils.go
+++ b/cmd/kubeadm/app/util/audit/utils.go
@@ -69,6 +69,7 @@ func writePolicyToDisk(policyFile string, policy *auditv1beta1.Policy) error {
 
 // CreateDefaultAuditWebhookConfig writes the default audit webhook config to disk.
 func CreateDefaultAuditWebhookConfig(webhookConfigFile string) error {
+	return nil // TODO: confirm that default file is not needed
 	webhookConfig := v1.Config{
 		Clusters: []v1.NamedCluster{
 			{Cluster: v1.Cluster{Server: "127.0.0.1", InsecureSkipTLSVerify: true}},


### PR DESCRIPTION
Fixing `--audit-webhook-config` option to make it possible to pass it through kubeadm to kube-apiserver